### PR TITLE
Update Central repository URL to use HTTPS

### DIFF
--- a/maven-index-search-suspect-coordinates/src/main/java/issc/Main.kt
+++ b/maven-index-search-suspect-coordinates/src/main/java/issc/Main.kt
@@ -55,7 +55,7 @@ object Main {
 
         // Create context for central repository index
         val centralContext = indexer.createIndexingContext("central-context", "central", centralLocalCache, centralIndexDir,
-            "http://repo1.maven.org/maven2", null, true, true, indexers)
+            "https://repo.maven.apache.org/maven2/", null, true, true, indexers)
 
         println("Updating Index...")
         println("This might take a while on first run, so please be patient!")


### PR DESCRIPTION
Also changes URL to use newer domain
See:
 https://support.sonatype.com/hc/en-us/articles/360041287334
 https://stackoverflow.com/questions/36155159/difference-between-http-repo-apache-maven-org-maven2-vs-http-repo1-maven-or