### PR TITLE
Update definitions

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1134,46 +1134,6 @@
             "new": "org.flowable:flowable-spring-boot-starter-process-rest"
         },
         {
-            "old": "org.hibernate:hibernate-agroal",
-            "new": "org.hibernate.orm:hibernate-agroal"
-        },
-        {
-            "old": "org.hibernate:hibernate-c3p0",
-            "new": "org.hibernate.orm:hibernate-c3p0"
-        },
-        {
-            "old": "org.hibernate:hibernate-core",
-            "new": "org.hibernate.orm:hibernate-core"
-        },
-        {
-            "old": "org.hibernate:hibernate-ehcache",
-            "new": "org.hibernate.orm:hibernate-ehcache"
-        },
-        {
-            "old": "org.hibernate:hibernate-enhance-maven-plugin",
-            "new": "org.hibernate.orm:hibernate-enhance-maven-plugin"
-        },
-        {
-            "old": "org.hibernate:hibernate-entitymanager",
-            "new": "org.hibernate.orm:hibernate-entitymanager"
-        },
-        {
-            "old": "org.hibernate:hibernate-envers",
-            "new": "org.hibernate.orm:hibernate-envers"
-        },
-        {
-            "old": "org.hibernate:hibernate-graalvm",
-            "new": "org.hibernate.orm:hibernate-graalvm"
-        },
-        {
-            "old": "org.hibernate:hibernate-gradle-plugin",
-            "new": "org.hibernate.orm:hibernate-gradle-plugin"
-        },
-        {
-            "old": "org.hibernate:hibernate-hikaricp",
-            "new": "org.hibernate.orm:hibernate-hikaricp"
-        },
-        {
             "old": "org.hibernate:hibernate-infinispan",
             "new": "org.infinispan:infinispan-hibernate-cache"
         },
@@ -1182,40 +1142,12 @@
             "new": "org.infinispan:infinispan-hibernate-cache-v53"
         },
         {
-            "old": "org.hibernate:hibernate-java8",
-            "new": "org.hibernate.orm:hibernate-java8"
-        },
-        {
-            "old": "org.hibernate:hibernate-jcache",
-            "new": "org.hibernate.orm:hibernate-jcache"
-        },
-        {
-            "old": "org.hibernate:hibernate-jipijapa",
-            "new": "org.hibernate.orm:hibernate-jipijapa"
-        },
-        {
-            "old": "org.hibernate:hibernate-jpamodelgen",
-            "new": "org.hibernate.orm:hibernate-jpamodelgen"
-        },
-        {
-            "old": "org.hibernate:hibernate-osgi",
-            "new": "org.hibernate.orm:hibernate-osgi"
-        },
-        {
-            "old": "org.hibernate:hibernate-proxool",
-            "new": "org.hibernate.orm:hibernate-proxool"
-        },
-        {
             "old": "org.hibernate:hibernate-search-infinispan",
             "new": "org.infinispan:infinispan-directory-provider"
         },
         {
             "old": "org.hibernate:hibernate-search",
             "new": "org.hibernate:hibernate-search-orm"
-        },
-        {
-            "old": "org.hibernate:hibernate-testing",
-            "new": "org.hibernate.orm:hibernate-testing"
         },
         {
             "old": "org.hibernate:hibernate-validator-annotation-processor",
@@ -1232,10 +1164,6 @@
         {
             "old": "org.hibernate:hibernate-validator-osgi-karaf-features",
             "new": "org.hibernate.validator:hibernate-validator-osgi-karaf-features"
-        },
-        {
-            "old": "org.hibernate:hibernate-vibur",
-            "new": "org.hibernate.orm:hibernate-vibur"
         },
         {
             "old": "org.hibernate.javax.persistence:hibernate-jpa-2.2-api",

--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,22 +1,210 @@
 {
-    "version": "4",
-    "date": "2020/01/10",
+    "version": "5",
+    "date": "2020/11/24",
     "migration": [
+        {
+            "old": "acegisecurity",
+            "new": "org.acegisecurity"
+        },
+        {
+            "old": "activation:activation",
+            "new": "javax.activation:activation"
+        },
+        {
+            "old": "ant:ant",
+            "new": "org.apache.ant:ant"
+        },
+        {
+            "old": "antlr:antlr",
+            "new": "org.antlr:antlr"
+        },
+        {
+            "old": "aspectj",
+            "new": "org.aspectj"
+        },
+        {
+            "old": "axis",
+            "new": "org.apache.axis"
+        },
+        {
+            "old": "bcel:bcel",
+            "new": "org.apache.bcel:bcel"
+        },
         {
             "old": "bouncycastle",
             "new": "org.bouncycastle"
         },
         {
-            "old": "fulcrum",
-            "new": "org.apache.fulcrum"
+            "old": "bsh:bsh",
+            "new": "org.beanshell:bsh"
         },
         {
-            "old": "geronimo",
-            "new": "org.apache.geronimo"
+            "old": "cactus:cactus-ant",
+            "new": "cactus:cactus-ant-13"
         },
         {
-            "old": "bcel:bcel",
-            "new": "org.apache.bcel:bcel"
+            "old": "clover:clover",
+            "new": "com.cenqua.clover:clover"
+        },
+        {
+            "old": "cobertura",
+            "new": "net.sourceforge.cobertura"
+        },
+        {
+            "old": "com.actionbarsherlock:library",
+            "new": "com.actionbarsherlock:actionbarsherlock"
+        },
+        {
+            "old": "com.aoindustries:ao-web-page",
+            "new": "com.semanticcms:semanticcms-core-model"
+        },
+        {
+            "old": "com.aoindustries:ao-web-page-servlet",
+            "new": "com.semanticcms:semanticcms-core-servlet"
+        },
+        {
+            "old": "com.aoindustries:ao-web-page-taglib",
+            "new": "com.semanticcms:semanticcms-core-taglib"
+        },
+        {
+            "old": "com.aoindustries:ao-web-sitemap-servlet",
+            "new": "com.semanticcms:semanticcms-core-sitemap"
+        },
+        {
+            "old": "com.aoindustries:semanticcms-core-model",
+            "new": "com.semanticcms:semanticcms-core-model"
+        },
+        {
+            "old": "com.aoindustries:semanticcms-core-servlet",
+            "new": "com.semanticcms:semanticcms-core-servlet"
+        },
+        {
+            "old": "com.avanza.astrix:astrix-provider",
+            "new": "com.avanza.astrix:astrix-core"
+        },
+        {
+            "old": "com.cloudbees.thirdparty:vijava",
+            "new": "com.vmware:vijava"
+        },
+        {
+            "old": "com.code-spotter:codespotter-maven-plugin",
+            "new": "com.coverity:ondemand-maven-plugin"
+        },
+        {
+            "old": "com.coronaide.lockdown",
+            "new": "org.starchartlabs.lockdown"
+        },
+        {
+            "old": "com.datastax.cassandra:cassandra-driver-core",
+            "new": "com.datastax.oss:java-driver-core"
+        },
+        {
+            "old": "com.datastax.dse:dse-java-driver-core",
+            "new": "com.datastax.oss:java-driver-core"
+        },
+        {
+            "old": "com.datastax.dse:dse-java-driver-core-shaded",
+            "new": "com.datastax.oss:java-driver-core-shaded"
+        },
+        {
+            "old": "com.datastax.dse:dse-java-driver-mapper-processor",
+            "new": "com.datastax.oss:java-driver-mapper-processor"
+        },
+        {
+            "old": "com.datastax.dse:dse-java-driver-mapper-runtime",
+            "new": "com.datastax.oss:java-driver-mapper-runtime"
+        },
+        {
+            "old": "com.datastax.dse:dse-java-driver-query-builder",
+            "new": "com.datastax.oss:java-driver-query-builder"
+        },
+        {
+            "old": "com.deliveredtechnologies:rulebook",
+            "new": "com.deliveredtechnologies:rulebook-core"
+        },
+        {
+            "old": "com.energizedwork:jfconfig-factories-jdkclock",
+            "new": "uk.cogfin:jfconfig-factories-jdkclock"
+        },
+        {
+            "old": "com.energizedwork:jfconfig",
+            "new": "uk.cogfin:jfconfig"
+        },
+        {
+            "old": "com.enioka.jqm:jqm-api-client-hibernate",
+            "new": "com.enioka.jqm:jqm-api-client-jdbc"
+        },
+        {
+            "old": "com.facebook.android:facebook-marketing",
+            "new": "com.facebook.android:facebook-core"
+        },
+        {
+            "old": "com.github.dblock:oshi-core",
+            "new": "com.github.oshi:oshi-core"
+        },
+        {
+            "old": "com.github.dblock:oshi-dist",
+            "new": "com.github.oshi:oshi-dist"
+        },
+        {
+            "old": "com.github.dblock:oshi-json",
+            "new": "com.github.oshi:oshi-json"
+        },
+        {
+            "old": "com.github.dblock:oshi-parent",
+            "new": "com.github.oshi:oshi-parent"
+        },
+        {
+            "old": "com.github.derjust:spring-data-dynamodb",
+            "new": "com.github.spring-data-dynamodb:spring-data-dynamodb"
+        },
+        {
+            "old": "com.github.s4u:jfatek",
+            "new": "org.simplify4u:jfatek"
+        },
+        {
+            "old": "com.github.s4u:jfatek",
+            "new": "org.simplify4u:jfatek"
+        },
+        {
+            "old": "com.github.s4u.plugins:pgpverify-maven-plugin",
+            "new": "org.simplify4u.plugins:pgpverify-maven-plugin"
+        },
+        {
+            "old": "com.github.s4u.plugins:sitemapxml-maven-plugin",
+            "new": "org.simplify4u.plugins:sitemapxml-maven-plugin"
+        },
+        {
+            "old": "com.github.spring-data-dynamodb:spring-data-dynamodb",
+            "new": "com.github.derjust:spring-data-dynamodb"
+        },
+        {
+            "old": "com.github.wnameless:json-flattener",
+            "new": "com.github.wnameless.json:json-flattener"
+        },
+        {
+            "old": "com.google.api-ads:adwords-lib",
+            "new": "com.google.api-ads:ads-lib"
+        },
+        {
+            "old": "com.google.api-ads:dfa-lib",
+            "new": "com.google.api-ads:ads-lib"
+        },
+        {
+            "old": "com.google.api-ads:dfp-lib",
+            "new": "com.google.api-ads:ads-lib"
+        },
+        {
+            "old": "com.google.apis:google-api-services-sql",
+            "new": "com.google.apis:google-api-services-sqladmin"
+        },
+        {
+            "old": "com.googlecode.openpojo:openpojo",
+            "new": "com.openpojo:openpojo"
+        },
+        {
+            "old": "com.google.code.reflection-utils:reflection-utils",
+            "new": "com.github.ekryd.reflection-utils:reflection-utils"
         },
         {
             "old": "com.graphql-java:graphiql-spring-boot-autoconfigure",
@@ -63,16 +251,1279 @@
             "new": "com.graphql-java-kickstart:voyager-spring-boot-starter"
         },
         {
+            "old": "com.hotels.beans:bean-utils-library",
+            "new": "com.hotels.beans:bull-bean-transformer"
+        },
+        {
+            "old": "com.ibatis:ibatis-common",
+            "new": "com.ibatis:ibatis2-common"
+        },
+        {
+            "old": "com.ibatis:ibatis-dao",
+            "new": "com.ibatis:ibatis2-dao"
+        },
+        {
+            "old": "com.ibatis:ibatis-sqlmap",
+            "new": "com.ibatis:ibatis2-sqlmap"
+        },
+        {
+            "old": "com.jayway.maven.plugins.android.generation2:maven-android-plugin",
+            "new": "com.jayway.maven.plugins.android.generation2:android-maven-plugin"
+        },
+        {
+            "old": "com.kakawait:cas-security-dynamic-service-resolver",
+            "new": "com.kakawait:spring-security-cas-extension"
+        },
+        {
+            "old": "com.lowagie:itext",
+            "new": "com.itextpdf:itextpdf"
+        }, {
+            "old": "com.mageddo.togglefirst:toggle-first-core",
+            "new": "com.mageddo:feature-switch"
+        },
+        {
+            "old": "com.mageddo.togglefirst:toggle-first-repo-jdbc",
+            "new": "com.mageddo:feature-switch"
+        },
+        {
+            "old": "com.marklogic:java-client-api",
+            "new": "com.marklogic:marklogic-client-api"
+        },
+        {
+            "old": "com.mattprovis:fluentmatcher-core",
+            "new": "com.mattprovis:fluentmatcher-maven-plugin"
+        },
+        {
+            "old": "com.mattprovis:fluentmatcher-maven-plugin-test",
+            "new": "com.mattprovis:fluentmatcher-maven-plugin"
+        },
+        {
+            "old": "com.mattprovis:fluentmatcher-parent",
+            "new": "com.mattprovis:fluentmatcher-maven-plugin"
+        },
+        {
+            "old": "com.microsoft.azure:azure-eventhubs",
+            "new": "com.azure:azure-messaging-eventhubs"
+        },
+        {
+            "old": "com.microsoft.azure:azure-eventhubs-eph",
+            "new": "com.azure:azure-messaging-eventhubs-checkpointstore-blob"
+        },
+        {
+            "old": "com.microsoft.azure:azure-keyvault",
+            "new": "com.azure:azure-keyvault"
+        },
+        {
+            "old": "com.microsoft.azure:azure-keyvault-core",
+            "new": "com.azure:azure-security-keyvault-keys"
+        },
+        {
+            "old": "com.microsoft.azure:azure-keyvault-cryptography",
+            "new": "com.azure:azure-security-keyvault-keys"
+        },
+        {
+            "old": "com.microsoft.azure:azure-keyvault-extensions",
+            "new": "com.azure:azure-keyvault-extensions"
+        },
+        {
+            "old": "com.microsoft.azure:azure-keyvault-webkey",
+            "new": "com.azure:azure-security-keyvault-keys"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management",
+            "new": "com.microsoft.azure:azure-svc-mgmt"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-compute",
+            "new": "com.microsoft.azure:azure-svc-mgmt-compute"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-media",
+            "new": "com.microsoft.azure:azure-svc-mgmt-media"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-network",
+            "new": "com.microsoft.azure:azure-svc-mgmt-network"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-scheduler",
+            "new": "com.microsoft.azure:azure-svc-mgmt-scheduler"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-sql",
+            "new": "com.microsoft.azure:azure-svc-mgmt-sql"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-storage",
+            "new": "com.microsoft.azure:azure-svc-mgmt-storage"
+        },
+        {
+            "old": "com.microsoft.azure:azure-management-websites",
+            "new": "com.microsoft.azure:azure-svc-mgmt-websites"
+        },
+        {
+            "old": "com.microsoft.azure:azure-spring-boot-dependencies",
+            "new": "com.microsoft.azure:azure-spring-boot-starter-parent"
+        },
+        {
+            "old": "com.microsoft.azure:azure-storage",
+            "new": "com.azure:azure-storage"
+        },
+        {
+            "old": "com.microsoft.azure:spring-data-documentdb",
+            "new": "com.microsoft.azure:spring-data-cosmosdb"
+        },
+        {
+            "old": "com.microsoft.windowsazure.storage:microsoft-windowsazure-storage-sdk",
+            "new": "com.microsoft.azure:azure-storage"
+        },
+        {
+            "old": "commons-email:commons-email",
+            "new": "org.apache.commons:commons-email"
+        },
+        {
+            "old": "com.mtvi.plateng.maven:maven-hudson-plugin",
+            "new": "org.jvnet.hudson.tools:maven-hudson-plugin"
+        },
+        {
             "old": "com.mysema.querydsl",
             "new": "com.querydsl"
+        },
+        {
+            "old": "com.nanohttpd",
+            "new": "org.nanohttpd"
+        },
+        {
+            "old": "com.opentable.components:otj-metrics",
+            "new": "com.opentable.components:otj-metrics-jaxrs"
+        },
+        {
+            "old": "com.opentable.components:otj-server",
+            "new": "com.opentable.components:otj-server-jaxrs"
         },
         {
             "old": "com.oracle.substratevm",
             "new": "org.graalvm.nativeimage"
         },
         {
+            "old": "com.semanticcms:semanticcms-sitemap-servlet",
+            "new": "com.semanticcms:semanticcms-core-sitemap"
+        },
+        {
+            "old": "com.semanticcms:semanticcms-view-content",
+            "new": "com.semanticcms:semanticcms-core-view-content"
+        },
+        {
+            "old": "com.sun.xml:saaj-impl",
+            "new": "com.sun.xml.messaging.saaj:saaj-impl"
+        },
+        {
+            "old": "com.typesafe:slick_2.10",
+            "new": "com.typesafe.slick:slick_2.10"
+        },
+        {
+            "old": "com.typesafe:slick-testkit_2.10",
+            "new": "com.typesafe.slick:slick-testkit_2.10"
+        },
+        {
+            "old": "com.wandrell.archetypes:library",
+            "new": "com.wandrell.maven.archetypes:library"
+        },
+        {
+            "old": "com.wandrell.maven:archetype-pom",
+            "new": "com.bernardomg.maven:archetype-pom"
+        },
+        {
+            "old": "com.wandrell.maven.archetypes:library-archetype",
+            "new": "com.bernardomg.maven.archetypes:library-archetype"
+        },
+        {
+            "old": "com.wandrell.maven:base-pom",
+            "new": "com.bernardomg.maven:base-pom"
+        },
+        {
+            "old": "com.wandrell:persistence-utils",
+            "new": "com.wandrell:repository-pattern"
+        },
+        {
+            "old": "com.wandrell.tabletop:dice",
+            "new": "com.bernardomg.tabletop:dice"
+        },
+        {
+            "old": "com.wandrell.tabletop.dreadball:dreadball-model-api",
+            "new": "com.bernardomg.tabletop.dreadball:dreadball-model-api"
+        },
+        {
+            "old": "com.wandrell.tabletop.dreadball:dreadball-model-default",
+            "new": "com.bernardomg.tabletop.dreadball:dreadball-model-default"
+        },
+        {
+            "old": "com.wandrell.tabletop.dreadball:dreadball-model-json",
+            "new": "com.bernardomg.tabletop.dreadball:dreadball-model-json"
+        },
+        {
+            "old": "com.wandrell.tabletop.dreadball:dreadball-model-persistence",
+            "new": "com.bernardomg.tabletop.dreadball:dreadball-model-persistence"
+        },
+        {
+            "old": "cz.geek:gooddata-java",
+            "new": "com.gooddata:gooddata-java"
+        },
+        {
+            "old": "dbunit:dbunit",
+            "new": "org.dbunit:dbunit"
+        },
+        {
+            "old": "de.cwkr:cwkr-checkstyle",
+            "new": "de.cwkr:cwkr-coding-guidelines"
+        },
+        {
+            "old": "de.cwkr:cwkr-coding-guidelines",
+            "new": "de.cwkr:cwkr-pmd"
+        },
+        {
+            "old": "de.cwkr:tracerr",
+            "new": "de.cwkr.validation:validation-util"
+        },
+        {
+            "old": "de.cwkr.validation:validation-util",
+            "new": "de.cwkr:cwkr-util"
+        },
+        {
+            "old": "de.cwkr.validation:validation-util",
+            "new": "de.cwkr:tracerr"
+        },
+        {
+            "old": "de.stklcode.jvault:connector",
+            "new": "de.stklcode.jvault:jvault-connector"
+        },
+        {
+            "old": "de.thksystems:tkscommons-crypto",
+            "new": "de.thksystems:tkscommons"
+        },
+        {
+            "old": "de.thksystems:tkscommons",
+            "new": "de.thksystems:tkscommons-lang"
+        },
+        {
+            "old": "de.thksystems:tkscommons-lang",
+            "new": "de.thksystems:tkscommons"
+        },
+        {
+            "old": "de.thksystems:tkscommons-xstream",
+            "new": "de.thksystems:tkscommons"
+        },
+        {
+            "old": "docbook:docbook-xml",
+            "new": "org.docbook:docbook-xml"
+        },
+        {
+            "old": "docbook:docbook-xsl",
+            "new": "org.docbook:docbook-xsl"
+        },
+        {
+            "old": "easymock:easymockclassextension",
+            "new": "org.easymock:easymockclassextension"
+        },
+        {
+            "old": "easymock:easymock",
+            "new": "org.easymock:easymock"
+        },
+        {
+            "old": "ehcache:ehcache",
+            "new": "net.sf.ehcache:ehcache"
+        },
+        {
+            "old": "eu.lp0.slf4j:slf4j-android",
+            "new": "uk.uuid:slf4j-android"
+        },
+        {
+            "old": "fi.jumi:jumi-actors",
+            "new": "fi.jumi.actors:jumi-actors"
+        },
+        {
+            "old": "fi.jumi:jumi-actors-maven-plugin",
+            "new": "fi.jumi.actors:jumi-actors-maven-plugin"
+        },
+        {
+            "old": "fi.jumi:thread-safety-agent",
+            "new": "fi.jumi.actors:thread-safety-agent"
+        },
+        {
+            "old": "fish.payara.arquillian:arquillian-payara-micro-5-managed",
+            "new": "fish.payara.arquillian:arquillian-payara-micro-managed"
+        },
+        {
+            "old": "fish.payara.arquillian:arquillian-payara-server-4-embedded",
+            "new": "fish.payara.arquillian:arquillian-payara-server-embedded"
+        },
+        {
+            "old": "fish.payara.arquillian:arquillian-payara-server-4-managed",
+            "new": "fish.payara.arquillian:arquillian-payara-server-managed"
+        },
+        {
+            "old": "fish.payara.arquillian:arquillian-payara-server-4-remote",
+            "new": "fish.payara.arquillian:arquillian-payara-server-remote"
+        },
+        {
+            "old": "fish.payara.arquillian:payara-container-4-common",
+            "new": "fish.payara.arquillian:payara-container-common"
+        },
+        {
+            "old": "freemarker:freemarker",
+            "new": "org.freemarker:freemarker"
+        },
+        {
+            "old": "fr.inria.atlanmod.neoemf:neoemf-blueprints",
+            "new": "fr.inria.atlanmod.neoemf:neoemf-data-blueprints-core"
+        },
+        {
+            "old": "fr.inria.atlanmod.neoemf:neoemf-blueprints-neo4j",
+            "new": "fr.inria.atlanmod.neoemf:neoemf-data-blueprints-neo4j"
+        },
+        {
+            "old": "fr.inria.atlanmod.neoemf:neoemf-graph",
+            "new": "fr.inria.atlanmod.neoemf:neoemf-data-blueprints"
+        },
+        {
+            "old": "fr.inria.atlanmod.neoemf:neoemf-hbase",
+            "new": "fr.inria.atlanmod.neoemf:neoemf-data-hbase"
+        },
+        {
+            "old": "fr.inria.atlanmod.neoemf:neoemf-map",
+            "new": "fr.inria.atlanmod.neoemf:neoemf-data-mapdb"
+        },
+        {
+            "old": "fulcrum",
+            "new": "org.apache.fulcrum"
+        },
+        {
+            "old": "geronimo",
+            "new": "org.apache.geronimo"
+        },
+        {
+            "old": "groovy:groovy-1.0-jsr",
+            "new": "groovy:groovy"
+        },
+        {
+            "old": "hibernate:hibernate",
+            "new": "org.hibernate:hibernate"
+        },
+        {
+            "old": "htmlunit:htmlunit",
+            "new": "net.sourceforge.htmlunit:htmlunit"
+        },
+        {
+            "old": "icu4j:icu4j",
+            "new": "com.ibm.icu:icu4j"
+        },
+        {
+            "old": "icu:icu4j",
+            "new": "com.ibm.icu:icu4j"
+        },
+        {
+            "old": "info.cukes",
+            "new": "io.cucumber"
+        },
+        {
+            "old": "io.github.animatedledstrip:animatedledstrip-kotlin-pi",
+            "new": "io.github.animatedledstrip:animatedledstrip-pi"
+        },
+        {
+            "old": "io.github.devopsix:hamcrest-mail",
+            "new": "org.devopsix:hamcrest-mail"
+        },
+        {
+            "old": "io.github.fast-classpath-scanner:fast-classpath-scanner",
+            "new": "io.github.classgraph:classgraph"
+        },
+        {
+            "old": "io.github.lukehutch:fast-classpath-scanner",
+            "new": "io.github.classgraph:classgraph"
+        },
+        {
+            "old": "io.github.openfeign:feign-java8",
+            "new": "io.github.openfeign:feign-core"
+        },
+        {
+            "old": "io.jenkins.tools:git-changelist-maven-extension",
+            "new": "io.jenkins.tools.incrementals:git-changelist-maven-extension"
+        },
+        {
+            "old": "io.quee.ktx.framework.dependencies:ktx-business-dependencies",
+            "new": "io.quee.ktx.radix:ktx-radix-dependencies"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-adapter",
+            "new": "io.quee.ktx.radix:ktx-radix-adapter"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-adapter-shared",
+            "new": "io.quee.ktx.radix:ktx-business-adapter-shared"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-action-usecase",
+            "new": "io.quee.ktx.radix:ktx-radix-development-usecase-action"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-identity",
+            "new": "io.quee.ktx.radix:ktx-radix-development-identity"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development",
+            "new": "io.quee.ktx.radix:ktx-radix-development"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-reactive-usecases",
+            "new": "io.quee.ktx.radix:ktx-radix-tool"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-shared",
+            "new": "io.quee.ktx.radix:ktx-radix-development-shared"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-store",
+            "new": "io.quee.ktx.radix:ktx-radix-development-store"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-development-usecases",
+            "new": "io.quee.ktx.radix:ktx-radix-development-usecase"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-framework",
+            "new": "io.quee.api.parent:quee-api-parent"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-framework",
+            "new": "io.quee.ktx.radix:ktx-radix"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-port",
+            "new": "io.quee.ktx.radix:ktx-radix-port"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-port-logger",
+            "new": "io.quee.ktx.radix:ktx-radix-port-logger"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-starter",
+            "new": "io.quee.ktx.radix:ktx-radix-starter"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-starter-logger",
+            "new": "io.quee.ktx.radix:ktx-radix-starter-logger"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-tool-http",
+            "new": "io.quee.ktx.radix:ktx-radix-tool-http"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-tool",
+            "new": "io.quee.ktx.radix:ktx-radix-tool"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-tool-json-dsl",
+            "new": "io.quee.ktx.radix:ktx-radix-tool-json-dsl"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-tool-test-dsl",
+            "new": "io.quee.ktx.radix:ktx-radix-tool-test-dsl"
+        },
+        {
+            "old": "io.quee.ktx.framework:ktx-business-tool-test",
+            "new": "io.quee.ktx.radix:ktx-radix-tool-test"
+        },
+        {
+            "old": "io.sgr:common-dependencies",
+            "new": "io.sgr.maven:common-dependencies"
+        },
+        {
+            "old": "io.sgr:io.sgr.base",
+            "new": "io.sgr.maven:maven-base"
+        },
+        {
+            "old": "io.sgr:io.sgr",
+            "new": "io.sgr:io.sgr.base"
+        },
+        {
+            "old": "io.smallrye:smallrye-config-common",
+            "new": "io.smallrye.config:smallrye-config-common"
+        },
+        {
+            "old": "io.smallrye:smallrye-config-docs",
+            "new": "io.smallrye.config:smallrye-config-docs"
+        },
+        {
+            "old": "io.smallrye:smallrye-config",
+            "new": "io.smallrye.config:smallrye-config"
+        },
+        {
+            "old": "io.smallrye:smallrye-config-parent",
+            "new": "io.smallrye.config:smallrye-config-parent"
+        },
+        {
+            "old": "io.smallrye:smallrye-config-release",
+            "new": "io.smallrye.config:smallrye-config-release"
+        },
+        {
+            "old": "io.wcm:io.wcm.testing.aem-mock",
+            "new": "io.wcm:io.wcm.testing.aem-mock.junit4"
+        },
+        {
+            "old": "itext:itext",
+            "new": "com.lowagie:itext"
+        },
+        {
+            "old": "jaas:jaas",
+            "new": "javax.security:jaas"
+        },
+        {
+            "old": "jaf:activation",
+            "new": "javax.activation:activation"
+        },
+        {
+            "old": "jarjar:jarjar",
+            "new": "com.tonicsystems:jarjar"
+        },
+        {
+            "old": "javacc:javacc",
+            "new": "net.java.dev.javacc:javacc"
+        },
+        {
+            "old": "javamail:javamail",
+            "new": "javax.mail:mail"
+        },
+        {
+            "old": "javamail:mail",
+            "new": "javax.mail:mail"
+        },
+        {
+            "old": "javassist:javassist",
+            "new": "jboss:javassist"
+        },
+        {
+            "old": "javax.xml:jaxb-api",
+            "new": "javax.xml.bind:jaxb-api"
+        },
+        {
+            "old": "javax.xml:jaxrpc",
+            "new": "javax.xml:jaxrpc-api"
+        },
+        {
+            "old": "javax.xml:jaxws-api",
+            "new": "javax.xml.ws:jaxws-api"
+        },
+        {
+            "old": "javax.xml.soap:saaj-impl",
+            "new": "com.sun.xml.messaging.saaj:saaj-impl"
+        },
+        {
+            "old": "jboss:javassist",
+            "new": "javassist:javassist"
+        },
+        {
+            "old": "jca:jca",
+            "new": "javax.resource:connector"
+        },
+        {
+            "old": "jca:jca",
+            "new": "javax.resource:connector-api"
+        },
+        {
+            "old": "jcharts:jcharts",
+            "new": "net.sf.jcharts:krysalis-jCharts"
+        },
+        {
+            "old": "jcifs:jcifs",
+            "new": "org.samba.jcifs:jcifs"
+        },
+        {
+            "old": "jdbc:jdbc",
+            "new": "javax.sql:jdbc-stdext"
+        },
+        {
+            "old": "jdbc:jdbc-stdext",
+            "new": "javax.sql:jdbc-stdext"
+        },
+        {
+            "old": "jdo:jdo",
+            "new": "javax.jdo:jdo"
+        },
+        {
+            "old": "jdom:jdom",
+            "new": "org.jdom:jdom"
+        },
+        {
+            "old": "jexcelapi:jxl",
+            "new": "net.sourceforge.jexcelapi:jxl"
+        },
+        {
+            "old": "jfreechart:jfreechart",
+            "new": "jfree:jfreechart"
+        },
+        {
+            "old": "jgrapht:jgrapht",
+            "new": "org.jgrapht:jgrapht-jdk1.5"
+        },
+        {
+            "old": "jms:jms",
+            "new": "javax.jms:jms"
+        },
+        {
+            "old": "jsch:jsch",
+            "new": "com.jcraft:jsch"
+        },
+        {
+            "old": "jspapi:jsp-api",
+            "new": "javax.servlet:jsp-api"
+        },
+        {
+            "old": "jstl:jstl",
+            "new": "javax.servlet:jstl"
+        },
+        {
+            "old": "jta:jta",
+            "new": "javax.transaction:jta"
+        },
+        {
+            "old": "jtds:jtds",
+            "new": "net.sourceforge.jtds:jtds"
+        },
+        {
+            "old": "jug:jug",
+            "new": "org.safehaus.jug:jug"
+        },
+        {
+            "old": "junit:junit-dep",
+            "new": "junit:junit"
+        },
+        {
+            "old": "jwebunit:jwebunit",
+            "new": "net.sourceforge.jwebunit:jwebunit"
+        },
+        {
+            "old": "jython:jython",
+            "new": "org.python:jython"
+        },
+        {
+            "old": "kxml2:kxml2",
+            "new": "net.sf.kxml:kxml2"
+        },
+        {
+            "old": "kxml:kxml",
+            "new": "net.sf.kxml:kxml2"
+        },
+        {
+            "old": "netbeans:cvslib",
+            "new": "org.netbeans:lib"
+        },
+        {
+            "old": "net.htmlparser:jericho-html",
+            "new": "net.htmlparser.jericho:jericho-html"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:common",
+            "new": "net.javacrumbs.future-converter:future-converter-common"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:java8-guava",
+            "new": "net.javacrumbs.future-converter:future-converter-java8-guava"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:rxjava-java8",
+            "new": "net.javacrumbs.future-converter:future-converter-rxjava-java8"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:spring-guava",
+            "new": "net.javacrumbs.future-converter:future-converter-spring-guava"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:spring-java8",
+            "new": "net.javacrumbs.future-converter:future-converter-spring-java8"
+        },
+        {
+            "old": "net.javacrumbs.future-converter:spring-rxjava",
+            "new": "net.javacrumbs.future-converter:future-converter-spring-rxjava"
+        },
+        {
+            "old": "net.java.dev.urlrewrite:urlrewritefilter",
+            "new": "org.tuckey:urlrewritefilter"
+        },
+        {
+            "old": "net.jockx:littleproxy",
+            "new": "xyz.rogfam:littleproxy"
+        },
+        {
+            "old": "net.ju-n:net-ju-n-parent",
+            "new": "net.nicoulaj:net-ju-n-parent"
+        },
+        {
+            "old": "net.ju-n:net-ju-n-parent",
+            "new": "net.nicoulaj:parent"
+        },
+        {
+            "old": "net.kieker-monitoring:kieker-aspectj",
+            "new": "net.kieker-monitoring:kieker"
+        },
+        {
+            "old": "net.kieker-monitoring:kieker-emf",
+            "new": "net.kieker-monitoring:kieker"
+        },
+        {
+            "old": "net.simonvt:android-menudrawer",
+            "new": "net.simonvt.menudrawer:menudrawer"
+        },
+        {
+            "old": "net.simonvt:android-menudrawer-parent",
+            "new": "net.simonvt.menudrawer:menudrawer-parent"
+        },
+        {
+            "old": "net.simonvt:android-menudrawer-sample",
+            "new": "net.simonvt.menudrawer.sample:samples"
+        },
+        {
+            "old": "ninja.leaping.configurate:configurate-core",
+            "new": "org.spongepowered:configurate-core"
+        },
+        {
+            "old": "ninja.leaping.configurate:configurate-gson",
+            "new": "org.spongepowered:configurate-gson"
+        },
+        {
+            "old": "ninja.leaping.configurate:configurate-hocon",
+            "new": "org.spongepowered:configurate-hocon"
+        },
+        {
+            "old": "ninja.leaping.configurate:configurate-json",
+            "new": "org.spongepowered:configurate-json"
+        },
+        {
+            "old": "ninja.leaping.configurate:configurate-yaml",
+            "new": "org.spongepowered:configurate-yaml"
+        },
+        {
+            "old": "nl.talsmasoftware:context-propagation-java8",
+            "new": "nl.talsmasoftware.context:context-propagation-java8"
+        },
+        {
+            "old": "nl.talsmasoftware:context-propagation",
+            "new": "nl.talsmasoftware.context:context-propagation"
+        },
+        {
+            "old": "nl.talsmasoftware:context-propagation-root",
+            "new": "nl.talsmasoftware.context:context-propagation-root"
+        },
+        {
+            "old": "opensymphony:quartz-jboss",
+            "new": "org.opensymphony.quartz:quartz-jboss"
+        },
+        {
+            "old": "opensymphony:quartz-oracle",
+            "new": "org.opensymphony.quartz:quartz-oracle"
+        },
+        {
+            "old": "opensymphony:quartz",
+            "new": "org.opensymphony.quartz:quartz"
+        },
+        {
+            "old": "opensymphony:quartz-weblogic",
+            "new": "org.opensymphony.quartz:quartz-weblogic"
+        },
+        {
+            "old": "org.akashihi.osm:parallelpbf",
+            "new": "com.wolt:parallelpbf"
+        },
+        {
+            "old": "org.apache.commons:commons-io",
+            "new": "commons-io:commons-io"
+        },
+        {
+            "old": "org.apache.maven.its:maven-core-it-support-old-location",
+            "new": "org.apache.maven.its:maven-core-it-support"
+        },
+        {
+            "old": "org.apache.maven:maven-core-it-support-old-location",
+            "new": "org.apache.maven:maven-core-it-support"
+        },
+        {
+            "old": "org.apache.sis:sis-core",
+            "new": "org.apache.sis:core"
+        },
+        {
+            "old": "org.apache.sis:sis-parent",
+            "new": "org.apache.sis:parent"
+        },
+        {
+            "old": "org.apache.sis:sis-webapp",
+            "new": "org.apache.sis.application:sis-webapp"
+        },
+        {
+            "old": "org.apache.sling:maven-sling-plugin",
+            "new": "org.apache.sling:sling-maven-plugin"
+        },
+        {
+            "old": "org.apache.sling:org.apache.sling.testing.osgi-mock",
+            "new": "org.apache.sling:org.apache.sling.testing.osgi-mock.junit4"
+        },
+        {
+            "old": "org.apache.sling:org.apache.sling.testing.sling-mock",
+            "new": "org.apache.sling:org.apache.sling.testing.sling-mock.junit4"
+        },
+        {
+            "old": "org.codehaus.mojo:sonar-maven-plugin",
+            "new": "org.sonarsource.scanner.maven:sonar-maven-plugin"
+        },
+        {
+            "old": "org.codehaus.sonar:sonar-maven3-plugin",
+            "new": "org.codehaus.sonar:sonar-maven-plugin"
+        },
+        {
+            "old": "org.codehaus.woodstox:wstx-asl",
+            "new": "org.codehaus.woodstox:woodstox-core-asl"
+        },
+        {
+            "old": "org.codehaus.woodstox:wstx-lgpl",
+            "new": "org.codehaus.woodstox:woodstox-core-asl"
+        },
+        {
+            "old": "org.codehaus.xfire:bcprov-jdk15",
+            "new": "bouncycastle:bcprov-jdk15"
+        },
+        {
+            "old": "org.codehaus.xfire:xmlsec",
+            "new": "xml-security:xmlsec"
+        },
+        {
+            "old": "org.docbook:docbook-xml",
+            "new": "net.sf.docbook:docbook-xml"
+        },
+        {
+            "old": "org.docbook:docbook-xsl",
+            "new": "net.sf.docbook:docbook-xsl"
+        },
+        {
+            "old": "org.eu.acolyte:acolyte-core",
+            "new": "org.eu.acolyte:jdbc-driver"
+        },
+        {
+            "old": "org.eu.acolyte:acolyte-scala_2.10",
+            "new": "org.eu.acolyte:jdbc-scala_2.10"
+        },
+        {
+            "old": "org.firebirdsql.jdbc:jaybird-jdk17",
+            "new": "org.firebirdsql.jdbc:jaybird"
+        },
+        {
+            "old": "org.firebirdsql.jdbc:jaybird-jdk18",
+            "new": "org.firebirdsql.jdbc:jaybird"
+        },
+        {
+            "old": "org.firebirdsql.jdbc:jaybird",
+            "new": "org.firebirdsql.jdbc:jaybird-jdk17"
+        },
+        {
+            "old": "org.firebirdsql.jdbc:jaybird",
+            "new": "org.firebirdsql.jdbc:jaybird-jdk18"
+        },
+        {
+            "old": "org.flowable:flowable-spring-boot-starter-basic",
+            "new": "org.flowable:flowable-spring-boot-starter-process"
+        },
+        {
+            "old": "org.flowable:flowable-spring-boot-starter-rest-api",
+            "new": "org.flowable:flowable-spring-boot-starter-process-rest"
+        },
+        {
+            "old": "org.hibernate:hibernate-agroal",
+            "new": "org.hibernate.orm:hibernate-agroal"
+        },
+        {
+            "old": "org.hibernate:hibernate-c3p0",
+            "new": "org.hibernate.orm:hibernate-c3p0"
+        },
+        {
+            "old": "org.hibernate:hibernate-core",
+            "new": "org.hibernate.orm:hibernate-core"
+        },
+        {
+            "old": "org.hibernate:hibernate-ehcache",
+            "new": "org.hibernate.orm:hibernate-ehcache"
+        },
+        {
+            "old": "org.hibernate:hibernate-enhance-maven-plugin",
+            "new": "org.hibernate.orm:hibernate-enhance-maven-plugin"
+        },
+        {
+            "old": "org.hibernate:hibernate-entitymanager",
+            "new": "org.hibernate.orm:hibernate-entitymanager"
+        },
+        {
+            "old": "org.hibernate:hibernate-envers",
+            "new": "org.hibernate.orm:hibernate-envers"
+        },
+        {
+            "old": "org.hibernate:hibernate-graalvm",
+            "new": "org.hibernate.orm:hibernate-graalvm"
+        },
+        {
+            "old": "org.hibernate:hibernate-gradle-plugin",
+            "new": "org.hibernate.orm:hibernate-gradle-plugin"
+        },
+        {
+            "old": "org.hibernate:hibernate-hikaricp",
+            "new": "org.hibernate.orm:hibernate-hikaricp"
+        },
+        {
+            "old": "org.hibernate:hibernate-infinispan",
+            "new": "org.infinispan:infinispan-hibernate-cache"
+        },
+        {
+            "old": "org.hibernate:hibernate-infinispan",
+            "new": "org.infinispan:infinispan-hibernate-cache-v53"
+        },
+        {
+            "old": "org.hibernate:hibernate-java8",
+            "new": "org.hibernate.orm:hibernate-java8"
+        },
+        {
+            "old": "org.hibernate:hibernate-jcache",
+            "new": "org.hibernate.orm:hibernate-jcache"
+        },
+        {
+            "old": "org.hibernate:hibernate-jipijapa",
+            "new": "org.hibernate.orm:hibernate-jipijapa"
+        },
+        {
+            "old": "org.hibernate:hibernate-jpamodelgen",
+            "new": "org.hibernate.orm:hibernate-jpamodelgen"
+        },
+        {
+            "old": "org.hibernate:hibernate-osgi",
+            "new": "org.hibernate.orm:hibernate-osgi"
+        },
+        {
+            "old": "org.hibernate:hibernate-proxool",
+            "new": "org.hibernate.orm:hibernate-proxool"
+        },
+        {
+            "old": "org.hibernate:hibernate-search-infinispan",
+            "new": "org.infinispan:infinispan-directory-provider"
+        },
+        {
+            "old": "org.hibernate:hibernate-search",
+            "new": "org.hibernate:hibernate-search-orm"
+        },
+        {
+            "old": "org.hibernate:hibernate-testing",
+            "new": "org.hibernate.orm:hibernate-testing"
+        },
+        {
+            "old": "org.hibernate:hibernate-validator-annotation-processor",
+            "new": "org.hibernate.validator:hibernate-validator-annotation-processor"
+        },
+        {
+            "old": "org.hibernate:hibernate-validator-cdi",
+            "new": "org.hibernate.validator:hibernate-validator-cdi"
+        },
+        {
+            "old": "org.hibernate:hibernate-validator",
+            "new": "org.hibernate.validator:hibernate-validator"
+        },
+        {
+            "old": "org.hibernate:hibernate-validator-osgi-karaf-features",
+            "new": "org.hibernate.validator:hibernate-validator-osgi-karaf-features"
+        },
+        {
+            "old": "org.hibernate:hibernate-vibur",
+            "new": "org.hibernate.orm:hibernate-vibur"
+        },
+        {
+            "old": "org.hibernate.javax.persistence:hibernate-jpa-2.2-api",
+            "new": "javax.persistence:javax.persistence-api"
+        },
+        {
+            "old": "org.hibernate.ogm:hibernate-ogm-infinispan",
+            "new": "org.hibernate.ogm:hibernate-ogm-infinispan-embedded"
+        },
+        {
+            "old": "org.hibernate.orm:hibernate-infinispan",
+            "new": "org.infinispan:infinispan-hibernate-cache-v53"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wlp-managed-8.5",
+            "new": "io.openliberty.arquillian:arquillian-liberty-managed"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wlp-remote-8.5",
+            "new": "io.openliberty.arquillian:arquillian-liberty-remote"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-managed-10.3",
+            "new": "org.jboss.arquillian.container:arquillian-wls-managed-10.3.x"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-managed-12.1.2",
+            "new": "org.jboss.arquillian.container:arquillian-wls-managed-12.1.x"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-managed-12.1",
+            "new": "org.jboss.arquillian.container:arquillian-wls-managed-12.1.x"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-remote-10.3",
+            "new": "org.jboss.arquillian.container:arquillian-wls-remote-10.3.x"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-remote-12.1.2",
+            "new": "org.jboss.arquillian.container:arquillian-wls-remote-12.1.x"
+        },
+        {
+            "old": "org.jboss.arquillian.container:arquillian-wls-remote-12.1",
+            "new": "org.jboss.arquillian.container:arquillian-wls-remote-12.1.x"
+        },
+        {
+            "old": "org.jboss.forge:forge-parser-java-api",
+            "new": "org.jboss.forge:java-parser-api"
+        },
+        {
+            "old": "org.jboss.forge:forge-parser-java",
+            "new": "org.jboss.forge:java-parser-impl"
+        },
+        {
+            "old": "org.jdtaus.core.monitor:jdtaus-core-client-monitoring",
+            "new": "org.jdtaus.core.monitor:jdtaus-core-task-monitor"
+        },
+        {
+            "old": "org.jdtaus.core.monitor:jdtaus-core-server-monitoring",
+            "new": "org.jdtaus.core.monitor:jdtaus-core-task-monitor"
+        },
+        {
+            "old": "org.jszip.jruby:sass-gems",
+            "new": "org.jszip.gems:sass-lang"
+        },
+        {
+            "old": "org.kitesdk:kite-data-hcatalog",
+            "new": "org.kitesdk:kite-data-hive"
+        },
+        {
+            "old": "org.kravemir.svg.labels:svg-labels",
+            "new": "org.kravemir.svg.labels:lablie"
+        },
+        {
+            "old": "org.kravemir.svg.labels:svg-labels-tool",
+            "new": "org.kravemir.svg.labels:lablie-tool"
+        },
+        {
+            "old": "org.labkey:labkey-client-api",
+            "new": "org.labkey.api:labkey-client-api"
+        },
+        {
+            "old": "org.mapstruct:mapstruct-jdk8",
+            "new": "org.mapstruct:mapstruct"
+        },
+        {
+            "old": "org.mortbay.jetty:maven-jetty-plugin",
+            "new": "org.mortbay.jetty:jetty-maven-plugin"
+        },
+        {
+            "old": "org.nuiton.js:nuiton-js-angular",
+            "new": "org.nuiton.js:nuiton-js-angularjs"
+        },
+        {
+            "old": "org.opendatakit:opendatakit-javarosa",
+            "new": "org.getodk:javarosa"
+        },
+        {
+            "old": "org.opendaylight.yangtools:features-test",
+            "new": "org.opendaylight.odlparent:features-test"
+        },
+        {
+            "old": "org.scalatest:scalatest",
+            "new": "org.scala-tools.testing:scalatest"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-base",
+            "new": "org.semanticweb.rulewerk:vlog-java"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-client",
+            "new": "org.semanticweb.rulewerk:rulewerk-client"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-core",
+            "new": "org.semanticweb.rulewerk:rulewerk-core"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-examples",
+            "new": "org.semanticweb.rulewerk:rulewerk-examples"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-graal",
+            "new": "org.semanticweb.rulewerk:rulewerk-graal"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-owlapi",
+            "new": "org.semanticweb.rulewerk:rulewerk-owlapi"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-parent",
+            "new": "org.semanticweb.rulewerk:rulewerk-pom"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-parser",
+            "new": "org.semanticweb.rulewerk:rulewerk-parser"
+        },
+        {
+            "old": "org.semanticweb.vlog4j:vlog4j-rdf",
+            "new": "org.semanticweb.rulewerk:rulewerk-rdf"
+        },
+        {
+            "old": "org.shaneking:org.shaneking.crypto",
+            "new": "org.shaneking:org.shaneking.skava"
+        },
+        {
+            "old": "org.shaneking:org.shaneking.ling",
+            "new": "org.shaneking:org.shaneking.skava"
+        },
+        {
+            "old": "org.shaneking:org.shaneking.sql",
+            "new": "org.shaneking:org.shaneking.skava"
+        },
+        {
+            "old": "org.slf4j:jcl104-over-slf4j",
+            "new": "org.slf4j:jcl-over-slf4j"
+        },
+        {
+            "old": "org.smartdeveloperhub.harvesters.scm.ldp4j:scm-harvester-ldp4j",
+            "new": "org.smartdeveloperhub.harvesters.scm:scm-harvester-frontend"
+        },
+        {
+            "old": "org.smartdeveloperhub.harvesters.scm:scm-harvester-container-ldp4j",
+            "new": "org.smartdeveloperhub.harvesters.scm:scm-harvester-container"
+        },
+        {
+            "old": "org.specsy:specsy-junit5",
+            "new": "org.specsy:specsy-junit"
+        },
+        {
+            "old": "org.truth0:truth",
+            "new": "com.google.truth:truth"
+        },
+        {
+            "old": "org.truth0:truth-parent",
+            "new": "com.google.truth:truth-parent"
+        },
+        {
+            "old": "poi:poi-2.5-final",
+            "new": "poi:poi"
+        },
+        {
+            "old": "poi:poi-contrib-2.5.1-final",
+            "new": "poi:poi"
+        },
+        {
+            "old": "poi:poi-contrib-2.5-final",
+            "new": "poi:poi-contrib"
+        },
+        {
+            "old": "poi:poi-contrib",
+            "new": "org.apache.poi:poi-contrib"
+        },
+        {
+            "old": "poi:poi",
+            "new": "org.apache.poi:poi"
+        },
+        {
+            "old": "poi:poi-scratchpad-2.5.1-final",
+            "new": "poi:poi"
+        },
+        {
+            "old": "poi:poi-scratchpad-2.5-final",
+            "new": "poi:poi"
+        },
+        {
+            "old": "poi:poi-scratchpad",
+            "new": "org.apache.poi:poi-scratchpad"
+        },
+        {
             "old": "postgresql",
             "new": "org.postgresql"
+        },
+        {
+            "old": "saxon:saxon",
+            "new": "net.sf.saxon:saxon"
+        },
+        {
+            "old": "servletapi:servlet-api",
+            "new": "javax.servlet:servlet-api"
+        },
+        {
+            "old": "servletapi:servletapi",
+            "new": "javax.servlet:servlet-api"
+        },
+        {
+            "old": "springframework",
+            "new": "org.springframework"
+        },
+        {
+            "old": "stax-utils:stax-utils",
+            "new": "net.java.dev.stax-utils:stax-utils"
+        },
+        {
+            "old": "tagsoup:tagsoup",
+            "new": "org.ccil.cowan.tagsoup:tagsoup"
+        },
+        {
+            "old": "tk.labyrinth:java-pig",
+            "new": "tk.labyrinth:jpig"
+        },
+        {
+            "old": "tonic:jarjar",
+            "new": "com.tonicsystems:jarjar"
+        },
+        {
+            "old": "uk.org.retep.microkernel:core",
+            "new": "uk.org.retep.microkernel:spring"
+        },
+        {
+            "old": "webtest:webtest",
+            "new": "com.canoo.webtest:webtest"
+        },
+        {
+            "old": "woodstox:wstx-asl",
+            "new": "org.codehaus.woodstox:wstx-asl"
+        },
+        {
+            "old": "woodstox:wstx-lgpl",
+            "new": "org.codehaus.woodstox:wstx-lgpl"
+        },
+        {
+            "old": "wutka:dtdparser",
+            "new": "com.wutka:dtdparser"
+        },
+        {
+            "old": "wutka:jox",
+            "new": "com.wutka:jox"
+        },
+        {
+            "old": "xerces:xerces",
+            "new": "xerces:xercesImpl"
+        },
+        {
+            "old": "xfire:saaj-impl",
+            "new": "com.sun.xml.messaging.saaj:saaj-impl"
+        },
+        {
+            "old": "xml-apis:xml-apis",
+            "new": "xerces:xmlParserAPIs"
+        },
+        {
+            "old": "xmlbeans:xmlbeans",
+            "new": "org.apache.xmlbeans:xmlbeans"
+        },
+        {
+            "old": "xstream:xstream",
+            "new": "com.thoughtworks.xstream:xstream"
         }
     ]
 }


### PR DESCRIPTION
I have followed upon the suggestion in #1 and created a crawler to list all relocated maven packages. 

It took more than a week to run and hundreds of gigabytes in disk space to keep all the million of pom.xml files

This is a fine strategy to bootstrap the JSON file, but I don't think it is a good strategy to keep the file up to date. 

The JSON file is (manually) ordered alphabetically by old groupid. 

This has already paid off in my company projects: https://github.com/premium-minds/billy/pull/136