### PR TITLE
Add jooby

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1306,6 +1306,10 @@
             "new": "org.jdtaus.core.monitor:jdtaus-core-task-monitor"
         },
         {
+            "old": "org.jooby",
+            "new": "io.jooby"
+        },
+        {
             "old": "org.jszip.jruby:sass-gems",
             "new": "org.jszip.gems:sass-lang"
         },


### PR DESCRIPTION
"org.jooby became io.jooby. Hence, use <groupId>org.jooby</groupId> for all dependencies."
https://jooby.io/#appendix-upgrading-from-x-maven-coordinates

Beware that jooby.org is scam site. The real site is now jooby.io.
See https://github.com/jooby-project/jooby/issues/1513#issuecomment-575512537