### PR TITLE
Add javax.mail-api

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -442,6 +442,10 @@
             "new": "com.semanticcms:semanticcms-core-view-content"
         },
         {
+            "old": "com.sun.mail:javax.mail",
+            "new": "com.sun.mail:jakarta.mail"
+        },
+        {
             "old": "com.sun.xml:saaj-impl",
             "new": "com.sun.xml.messaging.saaj:saaj-impl"
         },
@@ -852,6 +856,14 @@
         {
             "old": "javax.el:javax.el-api",
             "new": "jakarta.el:jakarta.el-api"
+        },
+        {
+            "old": "javax.mail:javax.mail-api",
+            "new": "jakarta.mail:jakarta.mail-api"
+        },
+        {
+            "old": "javax.mail:mail",
+            "new": "javax.mail:javax.mail-api"
         },
         {
             "old": "javax.persistence:javax.persistence-api",


### PR DESCRIPTION
JavaMail has moved to the Eclipse Foundation as part of the EE4J project, and will be included in the Jakarta EE specification.
The Maven coordinates for JavaMail are now:
	- com.sun.mail:jakarta.mail	- complete JavaMail jar file
	- jakarta.mail:jakarta.mail-api	- API jar file for compiling only

https://github.com/eclipse-ee4j/mail/blob/8667fa67a2d35c9780ec7bc96d494ad4d1a94222/doc/release/COMPAT.txt
https://github.com/eclipse-ee4j/mail/issues/338