### PR TITLE
Add hamcrest

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,6 +1,6 @@
 {
-    "version": "8",
-    "date": "2021/04/23",
+    "version": "9",
+    "date": "2021/05/27",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1354,6 +1354,21 @@
         {
             "old": "org.glassfish:javax.el",
             "new": "org.glassfish:jakarta.el"
+        },
+        {
+            "old": "org.hamcrest:hamcrest-all",
+            "new": "org.hamcrest:hamcrest",
+            "context": "One jar containing all classes of all the other jars. There are no new releases of this library since version 1.3. Please use the single hamcrest.jar instead. See http://hamcrest.org/JavaHamcrest/distributables#previous-versions-of-hamcrest"
+        },
+        {
+            "old": "org.hamcrest:hamcrest-library",
+            "new": "org.hamcrest:hamcrest",
+            "context": "The library of Matcher implementations which are based on the core functionality in hamcrest-core.jar. From Hamcrest version 2.x, all the classes in hamcrest-core.jar were moved into hamcrest.jar. See http://hamcrest.org/JavaHamcrest/distributables#previous-versions-of-hamcrest"
+        },
+        {
+            "old": "org.hamcrest:hamcrest-core",
+            "new": "org.hamcrest:hamcrest",
+            "context": "This was the core API to be used by third-party framework providers. This includes a foundation set of matcher implementations for common operations. This library was used as a dependency for many third-party libraries, including JUnit 4.x. From Hamcrest version 2.x, all the classes in hamcrest-core.jar were moved into hamcrest.jar. See http://hamcrest.org/JavaHamcrest/distributables#previous-versions-of-hamcrest"
         },
         {
             "old": "org.hibernate:hibernate-infinispan",


### PR DESCRIPTION
Prior to version 2.x, Hamcrest was distributed through multiple jars, described below.

    hamcrest-core.jar: This was the core API to be used by third-party framework providers. This includes a foundation set of matcher implementations for common operations. This library was used as a dependency for many third-party libraries, including JUnit 4.x. From Hamcrest version 2.x, all the classes in hamcrest-core.jar were moved into hamcrest.jar.

    hamcrest-library.jar: The library of Matcher implementations which are based on the core functionality in hamcrest-core.jar. From Hamcrest version 2.x, all the classes in hamcrest-core.jar were moved into hamcrest.jar.

    hamcrest-integration.jar: Provides integration between Hamcrest and other testing tools, such as jMock and EasyMock. It depends upon hamcrest-core.jar and hamcrest-library.jar. There are no new releases of this library since version 1.3.

    hamcrest-generator.jar: A tool to allow many Matcher implementations to be combined into a single class with static methods returning the different matchers so users don’t have to remember many classes/packages to import. Generates code. This library is only used internally at compile time. It is not necessary for the use of any of the other hamcrest libraries at runtime. There are no new releases of this library since version 1.3.

    hamcrest-all.jar: One jar containing all classes of all the other jars. There are no new releases of this library since version 1.3. Please use the single hamcrest.jar instead.

http://hamcrest.org/JavaHamcrest/distributables#previous-versions-of-hamcrest