### PR TITLE
Adds properties to @Parameters to support system properties

### DIFF
--- a/src/main/java/biz/lermitage/oga/CheckMojo.kt
+++ b/src/main/java/biz/lermitage/oga/CheckMojo.kt
@@ -23,19 +23,19 @@ import java.util.*
 class CheckMojo : AbstractMojo() {
 
     /** Alternative location for og-definitions.json config file. */
-    @Parameter(name = "ogDefinitionsUrl")
+    @Parameter(name = "ogDefinitionsUrl", property = "ogDefinitionsUrl")
     private val ogDefinitionsUrl: String? = null
 
     /** Location ignore list local file. */
-    @Parameter(name = "ignoreListFile")
+    @Parameter(name = "ignoreListFile", property = "ignoreListFile")
     private val ignoreListFile: String? = null
 
     /** Location ignore list remote url. */
-    @Parameter(name = "ignoreListUrl")
+    @Parameter(name = "ignoreListUrl", property = "ignoreListUrl")
     private val ignoreListUrl: String? = null
 
     /** Fail on error, otherwise display an error message only. */
-    @Parameter(name = "failOnError")
+    @Parameter(name = "failOnError", property = "failOnError")
     private val failOnError: Boolean = true
 
     @Parameter(property = "project", readonly = true)


### PR DESCRIPTION
https://maven.apache.org/guides/mini/guide-configuring-plugins.html#Generic_Configuration

this allows to run directly in the terminal without requiring to add the configuration to pom.xml:
```
$ mvn -q biz.lermitage.oga:oga-maven-plugin:1.4.1-SNAPSHOT:check -DfailOnError=false
```