### PR TITLE
Add osgi.core artifact relocation

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,6 +1,6 @@
 {
-    "version": "13",
-    "date": "2021/07/29",
+    "version": "14",
+    "date": "2021/08/03",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1538,6 +1538,26 @@
         {
             "old": "org.opendaylight.yangtools:features-test",
             "new": "org.opendaylight.odlparent:features-test"
+        },
+        {
+            "old": "org.osgi:core",
+            "new": "org.osgi:org.osgi.core"
+        },
+        {
+            "old": "org.osgi:org.osgi.annotation",
+            "new": "org.osgi:osgi.annotation"
+        },
+        {
+            "old": "org.osgi:org.osgi.compendium",
+            "new": "org.osgi:osgi.cmpn"
+        },
+        {
+            "old": "org.osgi:org.osgi.core",
+            "new": "org.osgi:osgi.core"
+        },
+        {
+            "old": "org.osgi:org.osgi.enterprise",
+            "new": "org.osgi:osgi.enterprise"
         },
         {
             "old": "org.scalatest:scalatest",


### PR DESCRIPTION
> "In addition to individual artifacts, some aggregate artifacts are provided which encapsulate multiple related specifications. They have artifactIds starting with osgi..
> 
>  There are dedicated build time artifacts which are not intended for use at runtime. These should be used with maven scope provided. For example, osgi.annotation and osgi.core."

https://docs.osgi.org/artifacts/
https://blog.osgi.org/2015/08/more-jars-on-maven-central-and-jcenter.html
https://blog.osgi.org/2015/08/release-6-of-osgi-compendium-osgi.html
https://github.com/osgi/osgi/commit/f0d4c6a4cb3ea06eba7d950f35b11f24769dd048