### PR TITLE
Add jetty websocket relocations

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,6 +1,6 @@
 {
-    "version": "18",
-    "date": "2021/10/26",
+    "version": "19",
+    "date": "2021/11/03",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1363,6 +1363,26 @@
         {
             "old": "org.docbook:docbook-xsl",
             "new": "net.sf.docbook:docbook-xsl"
+        },
+        {
+            "old": "org.eclipse.jetty.websocket:websocket-api",
+            "new": "org.eclipse.jetty.websocket:websocket-jetty-api"
+        },
+        {
+            "old": "org.eclipse.jetty.websocket:websocket-server",
+            "new": "org.eclipse.jetty.websocket:websocket-jetty-server"
+        },
+        {
+            "old": "org.eclipse.jetty.websocket:websocket-client",
+            "new": "org.eclipse.jetty.websocket:websocket-jetty-client"
+        },
+        {
+            "old": "org.eclipse.jetty.websocket:javax-websocket-server-impl",
+            "new": "org.eclipse.jetty.websocket:websocket-javax-server"
+        },
+        {
+            "old": "org.eclipse.jetty.websocket:javax-websocket-client-impl",
+            "new": "org.eclipse.jetty.websocket:websocket-javax-client"
         },
         {
             "old": "org.eu.acolyte:acolyte-core",


### PR DESCRIPTION
> "Migrating from Jetty 9.4.x to Jetty 10.0.x requires changes in the coordinates of the Maven artifact dependencies for WebSocket."

https://www.eclipse.org/jetty/documentation/jetty-10/programming-guide/index.html#pg-migration