### PR TITLE
Add groovy relocation

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1333,6 +1333,10 @@
             "new": "org.apache.velocity:velocity-engine-core"
         },
         {
+            "old": "org.codehaus.groovy",
+            "new": "org.apache.groovy"
+        },
+        {
             "old": "org.codehaus.mojo:sonar-maven-plugin",
             "new": "org.sonarsource.scanner.maven:sonar-maven-plugin"
         },


### PR DESCRIPTION
In Groovy 4.0, the groupId of the maven coordinates for Groovy have changed from org.codehaus.groovy to org.apache.groovy.
http://groovy-lang.org/releasenotes/groovy-4.0.html

Fixes #27