### PR TITLE
add logback-access-spring-boot-starter relocation

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1229,6 +1229,10 @@
             "new": "net.kieker-monitoring:kieker"
         },
         {
+            "old": "net.rakugakibox.spring.boot:logback-access-spring-boot-starter",
+            "new": "dev.akkinoc.spring.boot:logback-access-spring-boot-starter"
+        },
+        {
             "old": "net.simonvt:android-menudrawer",
             "new": "net.simonvt.menudrawer:menudrawer"
         },


### PR DESCRIPTION
logback-access-spring-boot-starter is relocated 
https://github.com/akkinoc/logback-access-spring-boot-starter/releases/tag/v3.0.0