### PR TITLE
Adds jdom2

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1659,6 +1659,10 @@
             "new": "org.jboss.forge:java-parser-impl"
         },
         {
+            "old": "org.jdom:jdom",
+            "new": "org.jdom:jdom2"
+        },
+        {
             "old": "org.jdtaus.core.monitor:jdtaus-core-client-monitoring",
             "new": "org.jdtaus.core.monitor:jdtaus-core-task-monitor"
         },


### PR DESCRIPTION
http://www.jdom.org/docs/faq.html#a0045

Which Maven artifact should I use?

All JDOM versions are available in the 'jdom' or 'jdom2' artifact in the org.jdom group on Maven. The maven artifacts are a mess with early JDOM 2.x versions appearing in the 'jdom' artifacts, and later 2.x versions in the 'jdom2' artifact. Maven does not allow the fixing of mistakes, so maven users wil just have to live with it as it is.

If your project is one that requires both JDOM 1.x and 2.x, then you can also use the 'jdom-legacy' artifact to pull in version 1.1.3 (or later 1.x version).