### PR TITLE
Add jaxws-maven-plugin

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "version": "31",
+    "version": "32",
     "date": "2023/11/07",
     "migration": [
         {
@@ -1714,6 +1714,11 @@
         {
             "old": "org.jvnet.jaxb2.maven2:maven-jaxb23-plugin",
             "new": "org.jvnet.jaxb:jaxb-maven-plugin"
+        },
+        {
+            "old": "org.jvnet.jax-ws-commons:jaxws-maven-plugin",
+            "new": "org.codehaus.mojo:jaxws-maven-plugin",
+            "context": "The original code was developed in the Codehaus Mojo project, then as of March 2007, the project moved to jax-ws-commons with version 1.x in org.codehaus.mojo groupId and version 2.x in org.jvnet.jax-ws-commons groupId."
         },
         {
             "old": "org.kitesdk:kite-data-hcatalog",


### PR DESCRIPTION
> The original code was developed in the Codehaus Mojo project, then as of March 2007, the project moved to jax-ws-commons with version 1.x in org.codehaus.mojo groupId and version 2.x in org.jvnet.jax-ws-commons groupId.

> In September 2015, for version 2.4, it went back to MojoHaus (the new home of Codehaus Mojo) in [org.codehaus.mojo groupId](https://repo.maven.apache.org/maven2/org/codehaus/mojo/jaxws-maven-plugin/).

http://www.mojohaus.org/jaxws-maven-plugin/