### PR TITLE
The official continuation of jaxws-maven-plugin is in Eclipse Foundation

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1717,8 +1717,8 @@
         },
         {
             "old": "org.jvnet.jax-ws-commons:jaxws-maven-plugin",
-            "new": "org.codehaus.mojo:jaxws-maven-plugin",
-            "context": "The original code was developed in the Codehaus Mojo project, then as of March 2007, the project moved to jax-ws-commons with version 1.x in org.codehaus.mojo groupId and version 2.x in org.jvnet.jax-ws-commons groupId."
+            "new": "com.sun.xml.ws:jaxws-maven-plugin",
+            "context": "The original version of this was developed in the codehaus mojo project, in March 2007, the project was moved to jax-ws-commons, but as of December 2018, the project is moved to Eclipse Foundation and plugin's group id is changed to com.sun.xml.ws."
         },
         {
             "old": "org.kitesdk:kite-data-hcatalog",


### PR DESCRIPTION
Oracle transferred all of its Java EE code to Eclipse.

https://blogs.oracle.com/javamagazine/post/transition-from-java-ee-to-jakarta-ee

The plugin at coordinates org.codehaus.mojo:jaxws-maven-plugin is a fork:
> forking jaxws-maven-plugin back to MojoHaus
https://groups.google.com/g/mojohaus-dev/c/mIhIByUWvrY/m/biqxWNXGAAAJ

It is not included in the og-unofficial-definitions.json because this fork seems to be abandoned and not updated for Jakarta.