### PR TITLE
Adds Eclipse Parsson

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,6 +1,6 @@
 {
-    "version": "33",
-    "date": "2023/11/10",
+    "version": "34",
+    "date": "2023/11/11",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1492,6 +1492,10 @@
         {
             "old": "org.flowable:flowable-spring-boot-starter-rest-api",
             "new": "org.flowable:flowable-spring-boot-starter-process-rest"
+        },
+        {
+            "old": "org.glassfish:jakarta.json",
+            "new": "org.eclipse.parsson:parsson"
         },
         {
             "old": "org.glassfish:javax.el",


### PR DESCRIPTION
> removed (default) implementation from the specification API artifact and moved the implementation to the separate project (Eclipse Parsson)
https://github.com/jakartaee/jsonp-api/releases/tag/2.1.0-RELEASE