### PR TITLE
Update og-unofficial-definitions.json with de.focus-shift:jollyday gav

### DIFF
--- a/uc/og-unofficial-definitions.json
+++ b/uc/og-unofficial-definitions.json
@@ -1,6 +1,6 @@
 {
-    "version": "2",
-    "date": "2022/11/26",
+    "version": "3",
+    "date": "2024/01/12",
     "migration": [
         {
             "old": "com.jcraft:jsch",
@@ -15,6 +15,13 @@
                 "net.datafaker:datafaker"
             ],
             "context": "This library is a modern fork of java-faker, built on Java 8, with up to date libraries and several newly added Fake Generators. See https://github.com/datafaker-net/datafaker/"
+        },
+        {
+            "old": "de.jollyday:jollyday",
+            "proposal": [
+                "de.focus-shift:jollyday"
+            ],
+            "context": "The old jollyday project is no longer maintained. This is a modern fork with jakarta dependencies and based on java 11."
         }
     ]
 }


### PR DESCRIPTION
The jollyday version of de.jollyday:jollyday is no longer maintained. We started a fork with de.focus-shift:jollyday

see https://github.com/svendiedrichsen/jollyday
see https://github.com/focus-shift/jollyday/