### PR TITLE
Fix #79 - Use plexus to support classpath resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ However, if you would like to get the benefit of the community maintained defini
 </plugin>
 ```
 
+In some cases your definition file might be shared across many projects.
+As an alternative to copying and pasting this file into each build, you can package your definitions into a JAR and reference it like so:
+```xml
+<plugin>
+    <groupId>biz.lermitage.oga</groupId>
+    <artifactId>oga-maven-plugin</artifactId>
+    <configuration>
+        <additionalDefinitionFiles>
+            <additionalDefinitionFile>classpath-og-definitions.json</additionalDefinitionFile>
+        </additionalDefinitionFiles>
+    </configuration>
+    <dependencies>
+        <!-- Dependency contains /classpath-og-definitions.json -->
+        <dependency>
+            <groupId>com.example.oga</groupId>
+            <artifactId>build-config</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+</plugin>
+```
+
 #### Ignoring definitions
 
 You can also provide a JSON ignore-list in order to exclude some *groupIds* or *groupId + artifactIds*:

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <version>${gson.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-resources</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
         <!-- fix maven 3.9.2+ warnings:
         Plugin should declare these Maven artifacts in `provided` scope: [org.apache.maven:maven-settings-builder:3.9.2, org.apache.maven:maven-builder-support:3.9.2, org.apache.maven:maven-artifact:3.9.2, org.apache.maven:maven-resolver-provider:3.9.2, org.apache.maven:maven-plugin-api:3.9.2, org.apache.maven:maven-core:3.9.2, org.apache.maven:maven-repository-metadata:3.9.2, org.apache.maven:maven-settings:3.9.2, org.apache.maven:maven-model-builder:3.9.2, org.apache.maven:maven-model:3.9.2]
         -->

--- a/src/main/java/biz/lermitage/oga/util/DefinitionsTools.kt
+++ b/src/main/java/biz/lermitage/oga/util/DefinitionsTools.kt
@@ -4,6 +4,7 @@ import biz.lermitage.oga.Dependency
 import biz.lermitage.oga.DependencyType
 import biz.lermitage.oga.cfg.Definitions
 import org.apache.maven.plugin.logging.Log
+import org.codehaus.plexus.resource.ResourceManager
 
 /**
  * Definitions tools.
@@ -12,9 +13,9 @@ import org.apache.maven.plugin.logging.Log
  */
 object DefinitionsTools {
 
-    fun loadDefinitionsFromUrl(url: String, log: Log): Definitions {
+    fun loadDefinitionsFromUrl(url: String, log: Log, locator: ResourceManager): Definitions {
         log.info("Loading definitions from $url")
-        val definitions = IOTools.readDefinitions(url)
+        val definitions = IOTools.readDefinitions(url, locator, log)
 
         val nbDefinitions = definitions.migration?.size
         var welcomeMsg = "Loaded $nbDefinitions definitions from '$url'"

--- a/src/test/resources/biz/lermitage/oga/classpath_build_config/pom.xml
+++ b/src/test/resources/biz/lermitage/oga/classpath_build_config/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Intentionally does not have a parent to emulate a 3rd party -->
+
+    <groupId>biz.lermitage.oga</groupId>
+    <artifactId>classpath-build-config</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Build Configuration</name>
+</project>

--- a/src/test/resources/biz/lermitage/oga/classpath_build_config/src/main/resources/classpath-og-definitions.json
+++ b/src/test/resources/biz/lermitage/oga/classpath_build_config/src/main/resources/classpath-og-definitions.json
@@ -1,0 +1,10 @@
+{
+    "version": "2",
+    "date": "2021/02/03",
+    "migration": [
+        {
+            "old": "org.mock-server",
+            "new": "com.example.classpath.dependency"
+        }
+    ]
+}

--- a/src/test/resources/biz/lermitage/oga/ko_classpath_definitions/pom.xml
+++ b/src/test/resources/biz/lermitage/oga/ko_classpath_definitions/pom.xml
@@ -37,8 +37,8 @@
                 </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>com.example.oga</groupId>
-                        <artifactId>build-config</artifactId>
+                        <groupId>biz.lermitage.oga</groupId>
+                        <artifactId>classpath-build-config</artifactId>
                         <version>1.0.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>

--- a/src/test/resources/biz/lermitage/oga/ko_classpath_definitions/pom.xml
+++ b/src/test/resources/biz/lermitage/oga/ko_classpath_definitions/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test CheckMojo</name>
+
+    <parent>
+        <groupId>biz.lermitage.oga</groupId>
+        <artifactId>parent-pom</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <!-- From the classpath og-definitions file -->
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
+            <version>5.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.lermitage.oga</groupId>
+                <artifactId>oga-maven-plugin</artifactId>
+                <configuration>
+                    <additionalDefinitionFiles>
+                        <!-- A file in the plugin dependency -->
+                        <additionalDefinitionFile>classpath-og-definitions.json</additionalDefinitionFile>
+                    </additionalDefinitionFiles>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example.oga</groupId>
+                        <artifactId>build-config</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #79 

The code here is inspired by the PMD maven plugin
https://github.com/apache/maven-pmd-plugin/blob/4afad98d229a6764d2ebdd246c037d1645c7cbb9/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java#L394

The aim is to support classpath configuration when using this plugin in parent aggregator projects where config is in a plugin dependency.