### PR TITLE
Adds kotlin-stdlib-common

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/04/24",
+    "date": "2024/06/03",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1719,6 +1719,10 @@
         {
             "old": "org.jdtaus.core.monitor:jdtaus-core-server-monitoring",
             "new": "org.jdtaus.core.monitor:jdtaus-core-task-monitor"
+        },
+        {
+            "old": "org.jetbrains.kotlin:kotlin-stdlib-common",
+            "new": "org.jetbrains.kotlin:kotlin-stdlib"
         },
         {
             "old": "org.jooby",


### PR DESCRIPTION
> The proposal is to publish no artifacts under kotlin-stdlib-common except a .pom file and a .module file with a universal variant that has the single dependency on kotlin-stdlib.

https://youtrack.jetbrains.com/issue/KT-60911/Compatibility-publishing-of-kotlin-stdlib-common 
https://github.com/JetBrains/kotlin/commit/3e4cbd6dd2460a567cbcf4f72b288a2ba4ff7ec9