### PR TITLE
Adds maven-replacer-plugin

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -260,6 +260,10 @@
             "new": "com.openpojo:openpojo"
         },
         {
+            "old": "com.google.code.maven-replacer-plugin:maven-replacer-plugin",
+            "new": "com.google.code.maven-replacer-plugin:replacer"
+        },
+        {
             "old": "com.google.code.reflection-utils:reflection-utils",
             "new": "com.github.ekryd.reflection-utils:reflection-utils"
         },


### PR DESCRIPTION
> Plugin artifactId was renamed to "replacer" from "maven-replacer-plugin" due to a naming policy change from the Maven team

https://code.google.com/archive/p/maven-replacer-plugin/