### PR TITLE
Adds Jena

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/07/07",
+    "date": "2024/08/20",
     "migration": [
         {
             "old": "acegisecurity",
@@ -314,6 +314,11 @@
         {
             "old": "com.hotels.beans:bean-utils-library",
             "new": "com.hotels.beans:bull-bean-transformer"
+        },
+        {
+            "old": "com.hp.hpl.jena",
+            "new": "org.apache.jena",
+            "context": "Jena was originally developed by researchers in HP Labs. (...) The project team successfully applied to have Jena adopted by the Apache Software Foundation in November 2010"
         },
         {
             "old": "com.ibatis:ibatis-common",


### PR DESCRIPTION
> History
>
> Jena was originally developed by researchers in HP Labs, starting in
> Bristol, UK, in 2000. Jena has always been an open-source project, and
> has been extensively used in a wide variety of semantic web applications
> and demonstrators. In 2009, HP decided to refocus development activity
> away from direct support of development of Jena, though remaining
> supportive of the project’s aims. The project team successfully applied
> to have Jena adopted by the Apache Software Foundation in November 2010
> (see the vote result).

https://jena.apache.org/about_jena/about.html