### PR TITLE
Adds opentelemetry-extension-annotations

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/09/10",
+    "date": "2024/09/13",
     "migration": [
         {
             "old": "acegisecurity",
@@ -805,6 +805,11 @@
         {
             "old": "io.jenkins.tools:git-changelist-maven-extension",
             "new": "io.jenkins.tools.incrementals:git-changelist-maven-extension"
+        },
+        {
+            "old": "io.opentelemetry:opentelemetry-extension-annotations",
+            "new": "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations",
+            "context": "Deprecated with v1.17.0 and moved to new coordinates"
         },
         {
             "old": "io.quee.ktx.framework.dependencies:ktx-business-dependencies",


### PR DESCRIPTION
> DEPRECATION: the opentelemetry-extension-annotations module containing @WithSpan and @SpanAttribute annotations has been deprecated for removal in next major version. A copy of the code will instead be maintained in opentelemetry-java-instrumentation/instrumentation-annotations and published under coordinates io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:{version}.

https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.17.0