### PR TITLE
Adds duplicate-finder-maven-plugin

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/10/15",
+    "date": "2024/10/21",
     "migration": [
         {
             "old": "acegisecurity",
@@ -528,6 +528,12 @@
             "old": "com.nanohttpd",
             "new": "org.nanohttpd"
         },
+        {
+            "old": "com.ning.maven.plugins:maven-duplicate-finder-plugin",
+            "new": "org.basepom.maven:duplicate-finder-maven-plugin",
+            "context": "Starting with version 1.1.0, the duplicate finder plugin has moved."
+        },
+
         {
             "old": "com.opentable.components:otj-metrics",
             "new": "com.opentable.components:otj-metrics-jaxrs"


### PR DESCRIPTION
> Starting with version 1.1.0, the duplicate finder plugin has moved.
> Please contribute any pull requests, but reports etc. to the the new location.

https://github.com/ning/maven-duplicate-finder-plugin

> This plugin is a friendly fork (same main authors) of the Ning maven-duplicate-finder plugin. It is configuration compatible to the ning plugin; the only change required is the group and artifact id of the plugin itself.

https://github.com/basepom/duplicate-finder-maven-plugin