### PR TITLE
Adds fabric8-maven-plugin

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -799,6 +799,10 @@
             "context": "This project has been rebranded to https://github.com/eclipse-jkube/jkube."
         },
         {
+            "old": "io.fabric8:maven-model-interpreter",
+            "new": "io.fabric8:maven-model-helper"
+        },
+        {
             "old": "io.github.benas:random-beans",
             "new": "org.jeasy:easy-random-core"
         },

--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -794,6 +794,11 @@
             "new": "io.cucumber"
         },
         {
+            "old": "io.fabric8:fabric8-maven-plugin",
+            "new": "org.eclipse.jkube:kubernetes-maven-plugin",
+            "context": "This project has been rebranded to https://github.com/eclipse-jkube/jkube."
+        },
+        {
             "old": "io.github.benas:random-beans",
             "new": "org.jeasy:easy-random-core"
         },
@@ -1542,6 +1547,10 @@
         {
             "old": "org.eclipse.jetty.websocket:javax-websocket-client-impl",
             "new": "org.eclipse.jetty.websocket:websocket-javax-client"
+        },
+        {
+            "old": "org.eclipse.jkube:k8s-maven-plugin",
+            "new": "org.eclipse.jkube:kubernetes-maven-plugin"
         },
         {
             "old": "org.eu.acolyte:acolyte-core",


### PR DESCRIPTION
> This project has been deprecated and is no longer under active development.
>
> Use Eclipse JKube instead.
>
> This project has been rebranded to https://github.com/eclipse-jkube/jkube.
>
> The Fabric8 Maven Plugin is no longer supported.
>
> All new features and support can be requested in the Eclipse JKube project.

https://github.com/fabric8io/fabric8-maven-plugin

https://github.com/eclipse-jkube/jkube/commit/0d02f1ebc003586d10a8a6ba52861218dfca1411