### PR TITLE
Adds assertj

### DIFF
--- a/uc/og-unofficial-definitions.json
+++ b/uc/og-unofficial-definitions.json
@@ -22,13 +22,19 @@
             ],
             "context": "The old jollyday project is no longer maintained. This is a modern fork with jakarta dependencies and based on java 11."
         },
-
         {
             "old": "com.google.code.findbugs",
             "proposal": [
                 "com.github.spotbugs"
             ],
             "context": "SpotBugs is a fork of FindBugs (which is now an abandoned project), carrying on from the point where it left off with support of its community."
+        },
+        {
+            "old": "org.easytesting:fest-assert-core",
+            "proposal": [
+                "org.assertj:assertj-core"
+            ],
+            "context": "AssertJ is a fork of Fest and there are very few breaking changes."
         }
     ]
 }


### PR DESCRIPTION
> Migrating from Fest 2.x is easy since AssertJ is a fork of Fest and there are very few breaking changes.

https://joel-costigliola.github.io/assertj/assertj-core-migrating-from-fest.html