### PR TITLE
Adds fastjson

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/12/28",
+    "date": "2024/12/30",
     "migration": [
         {
             "old": "acegisecurity",
@@ -66,6 +66,10 @@
         {
             "old": "com.actionbarsherlock:library",
             "new": "com.actionbarsherlock:actionbarsherlock"
+        },
+        {
+            "old": "com.alibaba:fastjson",
+            "new": "com.alibaba.fastjson2:fastjson2"
         },
         {
             "old": "com.aoindustries:ao-web-page",


### PR DESCRIPTION
> FASTJSON v2 is an upgrade of the FASTJSON, with the goal of providing a highly optimized JSON library for the next ten years.
> FASTJSONv2's groupId is different from versions 1.x, it is instead com.alibaba.fastjson2:

https://github.com/alibaba/fastjson2/blob/main/README_EN.md