### PR TITLE
Adds scala-maven-plugin

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2025/01/20",
+    "date": "2025/03/06",
     "migration": [
         {
             "old": "acegisecurity",
@@ -1958,6 +1958,10 @@
         {
             "old": "org.scalatest:scalatest",
             "new": "org.scala-tools.testing:scalatest"
+        },
+        {
+            "old": "org.scala-tools:maven-scala-plugin",
+            "new": "net.alchim31.maven:scala-maven-plugin"
         },
         {
             "old": "org.scribe",


### PR DESCRIPTION
> The scala-maven-plugin (previously maven-scala-plugin) is used for compiling/testing/running/documenting scala code in maven.
https://github.com/davidB/scala-maven-plugin

> move from org.scala-tools to net.alchim31.maven (repo sonatype)
https://github.com/davidB/scala-maven-plugin/commit/47ee913e0740e4ed190478217c10fbe12e36649b

> rename artifactId from maven-scala-plugin to scala-maven-plugin (follow maven rules and warning)
https://github.com/davidB/scala-maven-plugin/commit/bcba69243719071cd54706fbad3bbca260741e7d