### PR TITLE
Adds com.rabbitmq:rabbitmq-client

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2025/10/06",
+    "date": "2025/10/07",
     "migration": [
         {
             "old": "acegisecurity",
@@ -485,6 +485,10 @@
         {
             "old": "com.microsoft.windowsazure.storage:microsoft-windowsazure-storage-sdk",
             "new": "com.microsoft.azure:azure-storage"
+        },
+        {
+            "old": "com.rabbitmq:rabbitmq-client",
+            "new": "com.rabbitmq:amqp-client"
         },
         {
             "old": "commons-dbcp:commons-dbcp",


### PR DESCRIPTION
Could not find oficial documentation, but com.rabbitmq:rabbitmq-client:1.3.0 is binary equivalent to com.rabbitmq:amqp-client:1.3.0.