### PR TITLE
Adds unirest

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2025/11/21",
+    "date": "2025/11/24",
     "migration": [
         {
             "old": "acegisecurity",
@@ -384,6 +384,10 @@
             "new": "com.kakawait:spring-security-cas-extension"
         },
         {
+            "old": "com.konghq:unirest-java",
+            "new": "com.konghq:unirest-java-core"
+        },
+        {
             "old": "com.lowagie:itext",
             "new": "com.itextpdf:itextpdf"
         }, {
@@ -397,6 +401,10 @@
         {
             "old": "com.marklogic:java-client-api",
             "new": "com.marklogic:marklogic-client-api"
+        },
+        {
+            "old": "com.mashape.unirest:unirest-java",
+            "new": "com.konghq:unirest-java"
         },
         {
             "old": "com.mattprovis:fluentmatcher-core",
@@ -841,6 +849,10 @@
         {
             "old": "io.github.openfeign:feign-java8",
             "new": "io.github.openfeign:feign-core"
+        },
+        {
+            "old": "io.github.openunirest:unirest-java",
+            "new": "com.konghq:unirest-java"
         },
         {
             "old": "io.javaslang",


### PR DESCRIPTION
It seems that unirest from mashape was abandoned and forked into openunirest. But then the openunirest fork was merged back into the original project and renamed from mashape to konghq.

https://github.com/Kong/unirest-java/issues/255 Merge OpenUnirest/unirest-java into Kong/unirest-java 
https://github.com/Kong/unirest-java/issues/241 Is this project dead?
> Good news, we will be merging OpenUnirest back into this project. Stay tuned!

https://github.com/Kong/unirest-java/issues/252 Call for maintainers !

https://github.com/Kong/unirest-java/issues/166 Project dead, new maintainer needed?

https://github.com/OpenUnirest/unirest-java
> This project has been merged with https://github.com/Kong/unirest-java

https://github.com/OpenUnirest/unirest-java/issues/32
> also, FYI, Kong is the new name of Mashape

https://kong.github.io/unirest-java/upgrade-guide/#upgrading-to-unirest-20-from-previous-versions
> The core Unirest package has been moved from kong.unirest to kong.unirest.core, this prevents classloader issues where Unirest 4 may conflict with previous versions which may also be on the classpath