### PR TITLE
Adds fork for vault-java-driver

### DIFF
--- a/uc/og-unofficial-definitions.json
+++ b/uc/og-unofficial-definitions.json
@@ -1,5 +1,5 @@
 {
-    "date": "2024/11/10",
+    "date": "2026/02/07",
     "migration": [
         {
             "old": "com.jcraft:jsch",
@@ -35,6 +35,13 @@
                 "org.assertj:assertj-core"
             ],
             "context": "AssertJ is a fork of Fest and there are very few breaking changes."
+        },
+        {
+            "old": "com.bettercloud:vault-java-driver",
+            "proposal": [
+                "io.github.jopenlibs:vault-java-driver"
+            ],
+            "context": "BetterCloud's vault-java-driver is one of the most commonly used Java clients for Hashicorp, but has had no activity or releases since December 2019. The project is not maintaining by author."
         }
     ]
 }


### PR DESCRIPTION
> Fork explanation
> BetterCloud's vault-java-driver is one of the most commonly used Java clients for Hashicorp, but has had no activity or releases since December 2019. The project is not maintaining by author.

https://github.com/jopenlibs/vault-java-driver

> This repo hasn't had any updates in six years, and I highly recommend migrating to Spring Vault or any current fork. Sadly, I just don't have any way of annoncing that other than issue comments.
https://github.com/BetterCloud/vault-java-driver/pull/245#issuecomment-3478076836