### PR TITLE
Add software.amazon.ion:ion-java -> com.amazon.ion:ion-java relocation

### DIFF
--- a/uc/og-definitions.json
+++ b/uc/og-definitions.json
@@ -2375,6 +2375,11 @@
             "new": "javax.servlet:servlet-api"
         },
         {
+            "old": "software.amazon.ion:ion-java",
+            "new": "com.amazon.ion:ion-java",
+            "context": "From version 1.4.0 onward, Amazon Ion for Java moved to the new group id and Java package name \"com.amazon.ion\". The legacy \"software.amazon.ion\" group id is deprecated. See https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html"
+        },
+        {
             "old": "springframework",
             "new": "org.springframework"
         },


### PR DESCRIPTION
## What

Adds an official relocation entry to `uc/og-definitions.json`:

- **old:** `software.amazon.ion:ion-java`
- **new:** `com.amazon.ion:ion-java`

## Why

From version 1.4.0 onward, [Amazon Ion for Java](https://github.com/amazon-ion/ion-java) moved to the new group id and Java package name `com.amazon.ion`. The legacy `software.amazon.ion` group id is [deprecated](https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html) and receives no new releases. The migration is a drop-in group id change (same artifactId `ion-java`).

Inserted in alphabetical order by `old` GAV, between `servletapi:servletapi` and `springframework`.